### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -175,7 +175,7 @@ The list of dependencies are the following:
 * sklearn
 * gensim
 * sklearn-crfsuite
-* fuzzywuzzy
+* rapidfuzz
 * tika
 * gensim
 * pyyaml

--- a/faro/email.py
+++ b/faro/email.py
@@ -1,5 +1,4 @@
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import process, fuzz
 
 
 class Corporative_Detection(object):
@@ -22,13 +21,12 @@ class Corporative_Detection(object):
 
         # searching for corporative mails of the type <company>@<company>.com
         _choice = process.extractOne(
-            email_parts[0], [email_parts[1]], scorer=fuzz.ratio)
+            email_parts[0], [email_parts[1]], scorer=fuzz.ratio, score_cutoff=60)
 
-        if _choice[1] > 60:
+        if not _choice:
             return False
 
-        return (True if self.email_model.predict(
-            [email_parts[0]])[0] == "1" else False)
+        return self.email_model.predict([email_parts[0]])[0] == "1"
 
     def __init__(self, email_model, corp_list=None):
         """ Initalization

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
-fuzzywuzzy==0.17.0
 gensim==3.7.3
 langdetect==1.0.7
 mox==0.5.3
 murmurhash==1.0.2
 numpy==1.16.4
 pandas==0.24.2
-python-Levenshtein==0.12.0
 PyYAML==5.1.1
+rapidfuzz==0.7.3
 scikit-learn==0.21.2
 sklearn-crfsuite==0.3.6
 python-dateutil==2.8.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy

I did not update the Dockerfile, but everything python-Levenshtein related can be removed from there + RapidFuzz has prebuild wheels on PyPi as long as you target one of the platforms that is supported by it (e.g. wheels for ARM processors can not be uploaded on PyPi)